### PR TITLE
Not using attrs when getting the first user defined manager.

### DIFF
--- a/polymorphic/base.py
+++ b/polymorphic/base.py
@@ -63,7 +63,7 @@ class PolymorphicModelBase(ModelBase):
             new_class.add_to_class(mgr_name, new_manager)
 
         # get first user defined manager; if there is one, make it the _default_manager
-        user_manager = self.get_first_user_defined_manager(model_name, attrs)
+        user_manager = new_class.get_first_user_defined_manager()
         if user_manager:
             def_mgr = user_manager._copy_to_model(new_class)
             #print '## add default manager', type(def_mgr)
@@ -120,11 +120,12 @@ class PolymorphicModelBase(ModelBase):
         return add_managers
 
     @classmethod
-    def get_first_user_defined_manager(self, model_name, attrs):
+    def get_first_user_defined_manager(self):
         mgr_list = []
-        for key, val in attrs.items():
-            if not isinstance(val, models.Manager): continue
-            mgr_list.append((val.creation_counter, key, val))
+        for key, val in self.__dict__.items():
+            item = getattr(self, key)
+            if not isinstance(item, models.Manager): continue
+            mgr_list.append((item.creation_counter, key, item))
         # if there are user defined managers, use first one as _default_manager
         if mgr_list:                        #
             _, manager_name, manager = sorted(mgr_list)[0]


### PR DESCRIPTION
When I tried to create a custom manager for a polymorphic model (actually a model that extends django-shop's Product model), I faced this error message when sending a request to the server:

```
TypeError at /
Error when calling the metaclass bases
    issubclass() arg 2 must be a class or tuple of classes
```

This one gave me around 20 hours of major pain in the brain. Comments will follow in the code.
