### PR TITLE
Avoid SQL query in pre_save_polymorphic()

### DIFF
--- a/polymorphic/polymorphic_model.py
+++ b/polymorphic/polymorphic_model.py
@@ -83,7 +83,7 @@ class PolymorphicModel(models.Model):
         field to figure out the real class of this object
         (used by PolymorphicQuerySet._get_real_instances)
         """
-        if not self.polymorphic_ctype:
+        if not self.polymorphic_ctype_id:
             self.polymorphic_ctype = ContentType.objects.get_for_model(self)
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Hi.

I noticed django-polymorphic executes an unnecessary query when saving models.

In case the model already has a `polymorphic_ctype_id`, testing for `self.polymorphic_ctype` will perform a `SELECT .. from django_content_type WHERE id = nn` query. This patch avoids that query by testing for `polymorphic_ctype_id` instead.

The query is visible in the django-debug-toolbar POST redirect page, when saving a polymorphic model.
