### PR TITLE
remove trailing slash

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include README.rst
 include LICENSE
 include DOCS.rst
 include CHANGES.rst
-recursive-include polymorphic/templates/ *.html
+recursive-include polymorphic/templates *.html


### PR DESCRIPTION
Python 2.6.6 on Windows 7

pip install -e git://github.com/chrisglass/django_polymorphic.git#egg=django_polymorphic

fails with exception: ValueError: path 'polymorphic/templates/' cannot end with '/'
