### PR TITLE
 Remove unused load statements in add_type_form.html

### DIFF
--- a/polymorphic/templates/admin/polymorphic/add_type_form.html
+++ b/polymorphic/templates/admin/polymorphic/add_type_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify adminmedia %}
+{% load i18n %}
 {% load url from future %}
 
 {% block breadcrumbs %}{% if not is_popup %}


### PR DESCRIPTION
In `add_type_form.html`, the `adminmedia` is loaded, but not being used.

In Django 1.5 this library isn't available anymore, so removing it also addresses Django 1.5 compatibility (see #16)
