### PR TITLE
Feature: Create from super

### DIFF
--- a/polymorphic/polymorphic_model.py
+++ b/polymorphic/polymorphic_model.py
@@ -199,32 +199,3 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
         add_all_super_models(self.__class__, result)
         add_all_sub_models(self.__class__, result)
         return result
-    
-    @classmethod
-    def create_from_super(cls, obj, **kwargs):
-        """Creates an instance of subclass cls from existing super class. 
-        The new subclass will be the same object with same database id 
-        and data as obj, but will be an instance of cls.
-        
-        obj must be an instance of the direct superclass of cls.
-        kwargs should contain all required fields of the subclass (cls).
-        
-        returns obj as an instance of cls.
-        """
-        import inspect
-        scls = inspect.getmro(cls)[1]
-        if scls != obj.__class__:
-            raise Exception('create_from_super can only be used if obj is one level of inheritance up from cls')
-        ptr = '{}_ptr_id'.format(scls.__name__.lower())
-        kwargs[ptr] = obj.id
-        # create the new base class with only fields that apply to  it.
-        nobj = cls(**kwargs)
-        nobj.save_base(raw=True)
-        # force update the content type, but first we need to
-        # retrieve a clean copy from the db to fill in the null
-        # fields otherwise they would be overwritten.
-        nobj = cls.objects.get(pk=obj.pk)
-        nobj.polymorphic_ctype = ContentType.objects.get_for_model(cls)
-        nobj.save()
-            
-        return nobj.get_real_instance() # cast to cls

--- a/polymorphic/tests.py
+++ b/polymorphic/tests.py
@@ -780,16 +780,16 @@ class PolymorphicTests(TestCase):
                                        field3='C3{}'.format(i))
             mc.save()
             field4 = 'D4{}'.format(i)
-            md = Model2D.create_from_super(mc, field4=field4)
+            md = Model2D.objects.create_from_super(mc, field4=field4)
             self.assertEqual(mc.id, md.id)
             self.assertEqual(mc.field1, md.field1)
             self.assertEqual(mc.field2, md.field2)
             self.assertEqual(mc.field3, md.field3)
             self.assertEqual(md.field4, field4)
         ma = Model2A.objects.create(field1='A1e')
-        self.assertRaises(Exception, Model2D.create_from_super, ma, field4='D4e')
+        self.assertRaises(Exception, Model2D.objects.create_from_super, ma, field4='D4e')
         mb = Model2B.objects.create(field1='B1e', field2='B2e')
-        self.assertRaises(Exception, Model2D.create_from_super, mb, field4='D4e')
+        self.assertRaises(Exception, Model2D.objects.create_from_super, mb, field4='D4e')
 
 
 class RegressionTests(TestCase):


### PR DESCRIPTION
I'm not sure if you want this feature, but I thought I'd offer it. Basically it allows you to convert a polymorphic model to a new class down the hierarchy (one level). For example, if ModelB subclasses ModelA then an instance of ModelA can become an instance of ModelB by adding the additional fields without changing it's primary key. 

I use this feature to create objects that need to be classified later.

There are 2 commits which can be applied separately:

One is the feature itself with a test. 

The other modifies the tests to work with MySQL. Apparently sqlite reuses ids where as MySQL does not, so I just push the ids into the repr strings for comparison. This is the simplest solution I could think of, but it's not ideal. At least they pass...
