### PR TITLE
Fix proposal for get_real_instance_class() for proxy models

### DIFF
--- a/polymorphic/polymorphic_model.py
+++ b/polymorphic/polymorphic_model.py
@@ -110,7 +110,9 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
 
         # Protect against bad imports (dumpdata without --natural) or other
         # issues missing with the ContentType models.
-        if model is not None and not issubclass(model, self.__class__):
+        if model is not None \
+        and not issubclass(model, self.__class__) \
+        and not issubclass(model, self.__class__._meta.proxy_for_model):
             raise RuntimeError("ContentType {0} for {1} #{2} does not point to a subclass!".format(
                 self.polymorphic_ctype_id, model, self.pk,
             ))


### PR DESCRIPTION
This PR addresses changes in the 0.5.4 branch which broke `get_real_instance_class()` for proxy models of polymorphic base classes

Consider the below model

```
class Catalog_Item(PolymorphicModel):
class Kit_Item(Catalog_Item):

class Stored_Catalog_Item(Catalog_Item):
    class Meta:
        proxy=True


# grab a Stored_Catalog_Item object that refers to a Kit_Item
stored_item = Stored_Catalog_Item.objects.get(id=1)
stored_item.get_real_instance() #  <= FAILS

# This works
stored_item = Catalog_Item.objects.get(id=1)
stored_item.get_real_instance()  # <=  FINE
```

this fails because of the call here 
https://github.com/chrisglass/django_polymorphic/blob/master/polymorphic/polymorphic_model.py#L113: `issubclass(model, self.__class__)`  where `model=Kit_Item` and `self.__class__=Stored_Catalog_Item` because `Kit_Item` isn't a child class of `Stored_Catalog_Item`, but rather`Catalog_Item`.

The fix I propose is actually pretty trivial in that it simply checks to see if `self.__class__` is a proxy model for a django polymorphic base class.:

```
if model is not None  \
and not issubclass(model, self.__class__) \
and not issubclass(model, self.__class__._meta.proxy_for_model):
```
