### PR TITLE
Lint and format with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,15 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.6
     hooks:
-    -   id: black
+      - id: ruff
+        args:
+          - --fix
+      - id: ruff-format
         exclude: '.*migrations.*'

--- a/polymorphic/admin/filters.py
+++ b/polymorphic/admin/filters.py
@@ -28,7 +28,7 @@ class PolymorphicChildModelFilter(admin.SimpleListFilter):
             value = None
         if value:
             # ensure the content type is allowed
-            for choice_value, _ in self.lookup_choices:
+            for choice_value, _ in self.lookup_choices:  # noqa: F402
                 if choice_value == value:
                     return queryset.filter(polymorphic_ctype_id=choice_value)
             raise PermissionDenied(

--- a/polymorphic/base.py
+++ b/polymorphic/base.py
@@ -7,10 +7,8 @@ import sys
 import warnings
 
 import django
-from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.base import ModelBase
-from django.db.models.manager import ManagerDescriptor
 
 from .managers import PolymorphicManager
 from .query import PolymorphicQuerySet

--- a/polymorphic/query_translate.py
+++ b/polymorphic/query_translate.py
@@ -16,7 +16,6 @@ from django.db.utils import DEFAULT_DB_ALIAS
 # They form a kind of small framework for easily adding more
 # functionality to filters and Q objects.
 # Probably a more general queryset enhancement class could be made out of them.
-from polymorphic import compat
 
 ###################################################################################
 # PolymorphicQuerySet support functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,31 @@ requires = [
     "django>=2.1",  # for makemessages
 ]
 
-[tool.isort]
-profile = "black"
-line_length = 99
-
-[tool.black]
+[tool.ruff]
 line-length = 99
-exclude = '''
-/(
-    \.git
-  | \.tox
-  | \.venv
-  | dist
-)/
-'''
+
+extend-ignore = [
+    "E501",
+]
+select = [
+    "E",
+    "F",
+    "I",
+    "W",
+]
+
+[tool.ruff.per-file-ignores]
+"example/**" = [
+    "F401",
+    "F403",
+    "F405",
+    "F841",
+    "I",
+]
+"polymorphic/tests/**" = [
+    "F401",
+    "F403",
+    "F405",
+    "F841",
+    "I",
+]

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 import os
 import sys
 
-from setuptools import find_packages, setup
-
 # When creating the sdist, make sure the django.mo file also exists:
 if "sdist" in sys.argv or "develop" in sys.argv:
     os.chdir("polymorphic")


### PR DESCRIPTION
This PR switches linting/formatting from flake8 + isort + black to [ruff](https://ruff.rs/) and its formatter.

It also adds a simple GitHub Actions step to run that linting.

The examples and tests are exempt from some of the lints for now, to keep the diff here manageable.

