### PR TITLE
Check if child node is Q instance for subquery expressions

### DIFF
--- a/polymorphic/query_translate.py
+++ b/polymorphic/query_translate.py
@@ -69,7 +69,7 @@ def translate_polymorphic_Q_object(queryset_model, potential_q_object, using=DEF
                 )
                 if new_expr:
                     node.children[i] = new_expr
-            else:
+            elif isinstance(child, models.Q):
                 # this Q object child is another Q object, recursively process this as well
                 tree_node_correct_field_specs(my_model, child)
 


### PR DESCRIPTION
Fixes bug when using `Exists` subqueries which are or-ed together:

```python
SomeModel.objects.filter(
   Exists(RelatedModelA.objects.filter(some_model=OuterRef("pk"))
   | Exists(RelatedModelB.objects.filter(some_model=OuterRef("pk"))
)
```

This is done usually for performance reasons, but it is a valid queryset. `Exist` instances ored together like this creates a `Q` instance, but the children are not themselves `Q` instances. They are `Exists` instances.