### PR TITLE
Auto-discover child models and inlines

### DIFF
--- a/polymorphic/admin/helpers.py
+++ b/polymorphic/admin/helpers.py
@@ -62,6 +62,7 @@ class PolymorphicInlineAdminFormSet(InlineAdminFormSet):
         for form in self.formset.extra_forms + self.formset.empty_forms:
             model = form._meta.model
             child_inline = self.opts.get_child_inline_instance(model)
+
             yield PolymorphicInlineAdminForm(
                 formset=self.formset,
                 form=form,
@@ -140,3 +141,19 @@ class PolymorphicInlineSupportMixin:
                 admin_formset.request = request
                 admin_formset.obj = obj
         return inline_admin_formsets
+
+
+def get_leaf_subclasses(cls):
+    "Get leaf subclasses of `cls` class"
+
+    result = []
+
+    subclasses = cls.__subclasses__()
+
+    if not subclasses:
+        result.append(cls)
+    else:
+        for subclass in subclasses:
+            result.extend(get_leaf_subclasses(subclass))
+
+    return result

--- a/polymorphic/admin/parentadmin.py
+++ b/polymorphic/admin/parentadmin.py
@@ -123,9 +123,14 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
         Return a list of polymorphic types for which the user has the permission to perform the given action.
         """
         self._lazy_setup()
+
+        child_models = self.get_child_models()
+        if not child_models:
+            raise ImproperlyConfigured("No child models are available.")
+
         choices = []
         content_types = ContentType.objects.get_for_models(
-            *self.get_child_models(), for_concrete_models=False
+            *child_models, for_concrete_models=False
         )
 
         for model, ct in content_types.items():


### PR DESCRIPTION
Allow by default to inspect for Model and Inline subclasses to populate the admin forms. Also raise a proper exception in case there are no child models defined.

Fixes #576.