### PR TITLE
Remove checking of OneToOneField type in determining primary key name.

### DIFF
--- a/polymorphic/base.py
+++ b/polymorphic/base.py
@@ -73,7 +73,7 @@ class PolymorphicModelBase(ModelBase):
         # determine the name of the primary key field and store it into the class variable
         # polymorphic_primary_key_name (it is needed by query.py)
         for f in new_class._meta.fields:
-            if f.primary_key and type(f) != models.OneToOneField:
+            if f.primary_key:
                 new_class.polymorphic_primary_key_name = f.name
                 break
 


### PR DESCRIPTION
Tripping over the same issue that was documented [here](https://github.com/jazzband/django-polymorphic/issues/53) back in 2013 and without a solution, I decided to get rid of the error-causing clause and live dangerously.

In my experience this works, but there might be edge cases (@vdboor mentions one) that this is supposed to protect against, which it won't now. But at least I can use my OneToOneField's