### PR TITLE
PolymorphicQuerySet: Prevent NoneType error in test___lookup

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -277,7 +277,8 @@ class PolymorphicQuerySet(QuerySet):
                 tree_node_test___lookup(self.model, a)
             elif hasattr(a, "get_source_expressions"):
                 for source_expression in a.get_source_expressions():
-                    test___lookup(source_expression)
+                    if source_expression is not None:
+                        test___lookup(source_expression)
             else:
                 assert "___" not in a.name, ___lookup_assert_msg
 


### PR DESCRIPTION
## Description:
This PR ensures that test___lookup only processes non-None source_expression values to prevent potential NoneType errors. The change adds a simple condition to check if source_expression is None before passing it to test___lookup.


## Changes:

Added a None check for source_expression before calling test___lookup.
Why this is needed:

- Prevents potential NoneType errors when evaluating query expressions.
- Ensures test___lookup is only invoked with valid values.
- Our unit tests start failing after migrating from Django 5.0.10 to 5.1.5 and start showing "AttributeError: 'NoneType' object has no attribute 'name'"
- Inspired by [this fix](https://github.com/jazzband/django-polymorphic/commit/88922d7d5e918f1338eeb9baeecb17ed98ed1261), which addressed a similar issue in django-polymorphic.