### PR TITLE
Use CSS variables for colors

### DIFF
--- a/polymorphic/static/polymorphic/css/polymorphic_inlines.css
+++ b/polymorphic/static/polymorphic/css/polymorphic_inlines.css
@@ -11,10 +11,10 @@
   position: absolute;
   top: 2.2em;
   left: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color, #ccc);
   border-radius: 4px;
   padding: 2px;
-  background-color: #fff;
+  background-color: var(--body-bg, #fff);
   z-index: 1000;
 }
 
@@ -35,7 +35,7 @@
 
 @media (prefers-color-scheme: dark) {
   .polymorphic-type-menu {
-    border: 1px solid #121212;
-    background-color: #212121;
+    border: 1px solid var(--border-color, #121212);
+    background-color: var(--body-bg, #212121);
   }
 }


### PR DESCRIPTION
More recent versions of Django admin use CSS variables to control the theming color, allowing a user to chose their color scheme independently from their preferred one. Previously, django-polymorphic supported different color schemes only via the `prefers-color-scheme` media query. This commit implements usage of CSS variables for colors, ensuring consistent compatibility with the rest of the admin interface.