### PR TITLE
Django 5.1+ compatibility for PolymorphicQuerySet._process_aggregate_args()

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -261,8 +261,8 @@ class PolymorphicQuerySet(QuerySet):
             """*args might be complex expressions too in django 1.8 so
             the testing for a '___' is rather complex on this one"""
             if a is None:
-                return # since Django v5.1, get_source_expressions() return can have None in its items
-                
+                return  # since Django v5.1, get_source_expressions() return can have None in its items
+
             if isinstance(a, Q):
 
                 def tree_node_test___lookup(my_model, node):

--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -260,6 +260,9 @@ class PolymorphicQuerySet(QuerySet):
         def test___lookup(a):
             """*args might be complex expressions too in django 1.8 so
             the testing for a '___' is rather complex on this one"""
+            if a is None:
+                return # since Django v5.1, get_source_expressions() return can have None in its items
+                
             if isinstance(a, Q):
 
                 def tree_node_test___lookup(my_model, node):


### PR DESCRIPTION
Since Django v5.1, django.db.models.Aggregate.get_source_expressions() can have None as item in the returned list, causing the final assert to fail.