### PR TITLE
Check for None on real_model in get_real_instance

### DIFF
--- a/polymorphic/models.py
+++ b/polymorphic/models.py
@@ -157,13 +157,16 @@ class PolymorphicModel(models.Model, metaclass=PolymorphicModelBase):
         retrieve objects, then the complete object with it's real class/type
         and all fields may be retrieved with this method.
 
+        If the model of the object's actual type does not exist (e.g. it was
+        removed but its ContentType still exists), this method returns self.
+
         .. note::
             Each method call executes one db query (if necessary).
             Use the :meth:`~polymorphic.managers.PolymorphicQuerySet.get_real_instances`
             to upcast a complete list in a single efficient query.
         """
         real_model = self.get_real_instance_class()
-        if real_model == self.__class__:
+        if real_model == self.__class__ or real_model is None:
             return self
         return real_model.objects.db_manager(self._state.db).get(pk=self.pk)
 

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -321,12 +321,14 @@ class PolymorphicTests(TransactionTestCase):
         o = Model2A.objects.non_polymorphic().get(field1="C1")
         assert o.get_real_instance().__class__ == Model2C
 
-    def test_get_real_instance_with_no_model_class(self):
-        ctype = ContentType.objects.create(app_label="tests", model="nonexisting")
+    def test_get_real_instance_with_stale_content_type(self):
+        ctype = ContentType.objects.create(app_label="tests", model="stale")
         o = Model2A.objects.create(field1="A1", polymorphic_ctype=ctype)
 
         assert o.get_real_instance_class() is None
-        assert o.get_real_instance().__class__ == Model2A
+        match = "does not have a corresponding model"
+        with pytest.raises(PolymorphicTypeInvalid, match=match):
+            o.get_real_instance()
 
     def test_non_polymorphic(self):
         self.create_model2abcd()

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -321,6 +321,13 @@ class PolymorphicTests(TransactionTestCase):
         o = Model2A.objects.non_polymorphic().get(field1="C1")
         assert o.get_real_instance().__class__ == Model2C
 
+    def test_get_real_instance_with_no_model_class(self):
+        ctype = ContentType.objects.create(app_label="tests", model="nonexisting")
+        o = Model2A.objects.create(field1="A1", polymorphic_ctype=ctype)
+
+        assert o.get_real_instance_class() is None
+        assert o.get_real_instance().__class__ == Model2A
+
     def test_non_polymorphic(self):
         self.create_model2abcd()
 


### PR DESCRIPTION
Fixes a bug where `PolymorphicModel`'s `get_real_instance()` raises an exception when `get_real_instance_class()` returns None.