### PR TITLE
Fix use of `is` and `is not` vs. ==

### DIFF
--- a/polymorphic/base.py
+++ b/polymorphic/base.py
@@ -73,7 +73,7 @@ class PolymorphicModelBase(ModelBase):
         # determine the name of the primary key field and store it into the class variable
         # polymorphic_primary_key_name (it is needed by query.py)
         for f in new_class._meta.fields:
-            if f.primary_key and type(f) != models.OneToOneField:
+            if f.primary_key and type(f) is not models.OneToOneField:
                 new_class.polymorphic_primary_key_name = f.name
                 break
 

--- a/polymorphic/models.py
+++ b/polymorphic/models.py
@@ -157,13 +157,16 @@ class PolymorphicModel(models.Model, metaclass=PolymorphicModelBase):
         retrieve objects, then the complete object with it's real class/type
         and all fields may be retrieved with this method.
 
+        If the model of the object's actual type does not exist (e.g. it was
+        removed but its ContentType still exists), this method returns self.
+
         .. note::
             Each method call executes one db query (if necessary).
             Use the :meth:`~polymorphic.managers.PolymorphicQuerySet.get_real_instances`
             to upcast a complete list in a single efficient query.
         """
         real_model = self.get_real_instance_class()
-        if real_model == self.__class__:
+        if real_model == self.__class__ or real_model is None:
             return self
         return real_model.objects.db_manager(self._state.db).get(pk=self.pk)
 

--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -267,7 +267,7 @@ class PolymorphicQuerySet(QuerySet):
                     for i in range(len(node.children)):
                         child = node.children[i]
 
-                        if type(child) == tuple:
+                        if type(child) is tuple:
                             # this Q object child is a tuple => a kwarg like Q( instance_of=ModelB )
                             assert "___" not in child[0], ___lookup_assert_msg
                         else:

--- a/polymorphic/showfields.py
+++ b/polymorphic/showfields.py
@@ -62,7 +62,7 @@ class ShowFieldBase:
             out = field.name
 
             # if this is the standard primary key named "id", print it as we did with older versions of django_polymorphic
-            if field.primary_key and field.name == "id" and type(field) == models.AutoField:
+            if field.primary_key and field.name == "id" and type(field) is models.AutoField:
                 out += f" {getattr(self, field.name)}"
 
             # otherwise, display it just like all other fields (with correct type, shortened content etc.)

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -321,6 +321,13 @@ class PolymorphicTests(TransactionTestCase):
         o = Model2A.objects.non_polymorphic().get(field1="C1")
         assert o.get_real_instance().__class__ == Model2C
 
+    def test_get_real_instance_with_no_model_class(self):
+        ctype = ContentType.objects.create(app_label="tests", model="nonexisting")
+        o = Model2A.objects.create(field1="A1", polymorphic_ctype=ctype)
+
+        assert o.get_real_instance_class() is None
+        assert o.get_real_instance().__class__ == Model2A
+
     def test_non_polymorphic(self):
         self.create_model2abcd()
 


### PR DESCRIPTION
CI currently crashes with ruff complaining about the use of `==` to compare types. This breaks CI on unrelated PRs.