### PR TITLE
Fix use of is and is not vs. ==

### DIFF
--- a/polymorphic/base.py
+++ b/polymorphic/base.py
@@ -73,7 +73,7 @@ class PolymorphicModelBase(ModelBase):
         # determine the name of the primary key field and store it into the class variable
         # polymorphic_primary_key_name (it is needed by query.py)
         for f in new_class._meta.fields:
-            if f.primary_key and type(f) != models.OneToOneField:
+            if f.primary_key and type(f) is not models.OneToOneField:
                 new_class.polymorphic_primary_key_name = f.name
                 break
 

--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -267,7 +267,7 @@ class PolymorphicQuerySet(QuerySet):
                     for i in range(len(node.children)):
                         child = node.children[i]
 
-                        if type(child) == tuple:
+                        if type(child) is tuple:
                             # this Q object child is a tuple => a kwarg like Q( instance_of=ModelB )
                             assert "___" not in child[0], ___lookup_assert_msg
                         else:

--- a/polymorphic/showfields.py
+++ b/polymorphic/showfields.py
@@ -62,7 +62,7 @@ class ShowFieldBase:
             out = field.name
 
             # if this is the standard primary key named "id", print it as we did with older versions of django_polymorphic
-            if field.primary_key and field.name == "id" and type(field) == models.AutoField:
+            if field.primary_key and field.name == "id" and type(field) is models.AutoField:
                 out += f" {getattr(self, field.name)}"
 
             # otherwise, display it just like all other fields (with correct type, shortened content etc.)


### PR DESCRIPTION
CI currently crashes with ruff complaining about the use of == to compare types. This breaks CI on unrelated PRs.