### PR TITLE
Django 5.1+ compatibility for PolymorphicQuerySet._process_aggregate_args()

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -260,6 +260,9 @@ class PolymorphicQuerySet(QuerySet):
         def test___lookup(a):
             """*args might be complex expressions too in django 1.8 so
             the testing for a '___' is rather complex on this one"""
+            if a is None:
+                return  # since Django v5.1, get_source_expressions() return can have None in its items
+
             if isinstance(a, Q):
 
                 def tree_node_test___lookup(my_model, node):

--- a/polymorphic/tests/migrations/0001_initial.py
+++ b/polymorphic/tests/migrations/0001_initial.py
@@ -2064,4 +2064,86 @@ class Migration(migrations.Migration):
             },
             bases=("auth.group", models.Model),
         ),
+        migrations.CreateModel(
+            name="ModelArticle",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "polymorphic_ctype",
+                    models.ForeignKey(
+                        editable=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="polymorphic_oms.article_set+",
+                        to="contenttypes.contenttype",
+                    ),
+                ),
+                (
+                    "sales_points",
+                    models.IntegerField(null=True),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name="ModelPackage",
+            fields=[
+                (
+                    "modelarticle_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="tests.modelarticle",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100)),
+            ],
+            bases=("tests.modelarticle", models.Model),
+        ),
+        migrations.CreateModel(
+            name="ModelComponent",
+            fields=[
+                (
+                    "modelarticle_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="tests.modelarticle",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100)),
+            ],
+            bases=("tests.modelarticle", models.Model),
+        ),
+        migrations.CreateModel(
+            name="ModelOrderLine",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "articles",
+                    models.ManyToManyField(related_name="modelorderline", to="tests.ModelArticle"),
+                ),
+            ]
+        )
     ]

--- a/polymorphic/tests/models.py
+++ b/polymorphic/tests/models.py
@@ -189,6 +189,22 @@ class ModelWithMyManager2(ShowFieldTypeAndContent, Model2A):
     field4 = models.CharField(max_length=10)
 
 
+class ModelArticle(PolymorphicModel):
+    sales_points = models.IntegerField()
+
+
+class ModelPackage(ModelArticle):
+    name = models.CharField(max_length=100)
+
+
+class ModelComponent(ModelArticle):
+    name = models.CharField(max_length=100)
+
+
+class ModelOrderLine(models.Model):
+    articles = models.ManyToManyField(ModelArticle, related_name="orderline")
+
+
 class MROBase1(ShowFieldType, PolymorphicModel):
     objects = MyManager()
     field1 = models.CharField(max_length=10)  # needed as MyManager uses it

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -4,7 +4,7 @@ import uuid
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models import Case, Count, FilteredRelation, Q, When
+from django.db.models import Case, Count, FilteredRelation, Q, Sum, When
 from django.db.utils import IntegrityError
 from django.test import TransactionTestCase
 
@@ -35,6 +35,7 @@ from polymorphic.tests.models import (
     ModelExtraC,
     ModelExtraExternal,
     ModelFieldNameTest,
+    ModelOrderLine,
     ModelShow1,
     ModelShow1_plain,
     ModelShow2,
@@ -982,6 +983,12 @@ class PolymorphicTests(TransactionTestCase):
             match="model lookup supported for keyword arguments only",
         ):
             Model2A.objects.aggregate(Count("Model2B___field2"))
+
+    def test_polymorphic__aggregate_empty_queryset(self):
+        """test the fix for test___lookup in Django 5.1+"""
+        line = ModelOrderLine.objects.create()
+        result = line.articles.aggregate(Sum("sales_points"))
+        assert result == {"sales_points__sum": None}
 
     def test_polymorphic__complex_aggregate(self):
         """test (complex expression on) aggregate (should work for annotate either)"""


### PR DESCRIPTION
@bckohan I tried to add a test for the change in https://github.com/jazzband/django-polymorphic/pull/629.
But i'm looking for some help, as unfortunately, the added code isn't hit by this test.

I'm running this with `tox -e py312-django52`. 
In order to run test just this test,  i changed `tox.ini` as follows:

```
[testenv]
setenv =
        ...
	PYTEST_ADDOPTS = -k test_polymorphic__aggregate_empty_queryset -s
 ```

The code in our project has these models (simplified):
```
class Article(PolymorphicModel):
    sales_points = models.IntegerField(verbose_name="Verkooppunten", null=True)  # type: ignore[var-annotated]

class AnalysisPackage(Article):
    name = models.CharField(max_length=100)

class ComponentListHeader(Article):
    name = models.CharField(max_length=100)

class OrderLine(TimeStampedModel, VenHLineMixin, models.Model):
    articles = models.ManyToManyField(  # type: ignore[var-annotated]
        Article, related_name="orderline", verbose_name="Artikelen"
    )

    def calculate_total_sales_points(self) -> int:
        article_points = self.articles.aggregate(Sum("sales_points"))[
            "sales_points__sum"
        ]
```

The error is triggered in a test in our project when we call `self.calculate_total_sales_points()`, more specific: In the `self.articles.aggregate(Sum("sales_points"))` part. In this case, there are no Articles / AnalysisPackages / ComponentListHeaders in the test database.

I tried copying these models in the test (`ModelArticle`, `ModelPackage`, `ModelComponent`, `ModelOrderLine`) but although the test passes, it does so without hitting the added line. In an interactive shell, i see that `test___lookup` is hit twice in the test, the values of `a` are `Sum(F(sales_points))` and  `F(sales_points)`.

Would you have any pointers?


 