### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - python-version: "3.8"
           - python-version: "3.9"
           - python-version: "3.10"
           - python-version: "3.11"

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ maintainer_email = tribaal@ubuntu.com
 url = https://github.com/jazzband/django-polymorphic
 download_url = https://github.com/jazzband/django-polymorphic/tarball/master
 keywords = django, polymorphic
+python_requires = >=3.9
 classifiers =
 	Development Status :: 5 - Production/Stable
 	Environment :: Web Environment
@@ -26,7 +27,6 @@ classifiers =
 	Operating System :: OS Independent
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3 :: Only
-	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-	py{38,39,310}-django{32}
-	py{38,39,310}-django{40}
-	py{38,39,310,311}-django{41}
-	py{38,39,310,311,312}-django{42}
+	py{39,310}-django{32}
+	py{39,310}-django{40}
+	py{39,310,311}-django{41}
+	py{39,310,311,312}-django{42}
 	py{310,311,312}-django{50}
 	py{310,311,312,313}-django{51}
 	py{310,311,312,313}-django{52}
@@ -42,7 +42,6 @@ commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
Python 3.8 has been EOL since October 2024.

This drops Python 3.8 from CI, and also adds the `python_requires` marker to declare 3.9+ is the only way to go.