### PR TITLE
Release to upstream and remove dynamic versioning

### DIFF
--- a/justfile
+++ b/justfile
@@ -238,4 +238,4 @@ validate_version VERSION:
 release VERSION:
     @just validate_version v{{ VERSION }}
     git tag -s v{{ VERSION }} -m "{{ VERSION }} Release"
-    git push origin v{{ VERSION }}
+    git push upstream v{{ VERSION }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-polymorphic"
-dynamic = ["version"]
+version = "4.2.0"
 description = "Seamless polymorphic inheritance for Django models."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -555,6 +555,7 @@ wheels = [
 
 [[package]]
 name = "django-polymorphic"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Dynamic versioning (in pyproject.toml) is convenient - but I prefer the double entry/double check method of specifying the version twice and using the release machinery to double check they match as a nice way to be extra sure we are publishing the version number we intend.