### PR TITLE
Defer to chunk_size parameter on .iterators for fetching get_real_instances()

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -16,6 +16,7 @@ API Documentation
    polymorphic.formsets
    polymorphic.managers
    polymorphic.models
+   polymorphic.query
    polymorphic.showfields
    polymorphic.templatetags
    polymorphic.utils

--- a/docs/api/polymorphic.query.rst
+++ b/docs/api/polymorphic.query.rst
@@ -1,0 +1,7 @@
+polymorphic.query
+=================
+
+.. automodule:: polymorphic.query
+    :members:
+    :show-inheritance:
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-v4.2.0 (2025-12-01)
+v4.2.0 (2025-12-04)
 -------------------
 
+* Implemented `Defer to chunk_size parameter on .iterators for fetching get_real_instances() <https://github.com/jazzband/django-polymorphic/pull/672>`_
 * Fixed `Show full admin context (breadcrumb and logout nav) in model type selection admin form <https://github.com/jazzband/django-polymorphic/pull/580>`_
 * Fixed `Issue with Autocomplete Fields in StackedPolymorphicInline.Child Inline <https://github.com/jazzband/django-polymorphic/issues/546>`_
 * Support Python 3.14 and Django 6.0, drop support for EOL python 3.9, Django 3.2, 4.0, 4.1 and 5.0.

--- a/justfile
+++ b/justfile
@@ -182,11 +182,11 @@ test-lock +PACKAGES: _lock-python
 test *TESTS:
     @just run pytest --cov-append {{ TESTS }}
 
-test-db DB_CLIENT="dev":
+test-db DB_CLIENT="dev" *TESTS:
     # No Optional Dependency Unit Tests
     # todo clean this up, rerunning a lot of tests
     uv sync --group {{ DB_CLIENT }}
-    @just run pytest --cov-append
+    @just run pytest --cov-append {{ TESTS }}
 
 # run the pre-commit checks
 precommit:


### PR DESCRIPTION
This PR fixes #465 

Previous behavior would generate a new WHERE IN query for every 100 objects. This behavior is not problematic for most workflows because they probably fetch fewer than 100 rows - but it is clearly undesirable and overly cautious for cases that pull many more rows.

Django ORM iterators accept a [chunk_size](https://docs.djangoproject.com/en/stable/ref/models/querysets/#django.db.models.query.QuerySet.iterator) parameter that is currently ignored by polymorphic querysets after the initial query during the get_real_instances phase. Nominally, chunk_size does not modify the number of sql queries performed but instead the number of rows fetched by the connection cursor. However, there is precedent in the Django ORM for using it this way, as it does control the number of queries issued when [prefetch_related](https://docs.djangoproject.com/en/stable/ref/models/querysets/#prefetch-related) is used. [prefetch_related](https://docs.djangoproject.com/en/stable/ref/models/querysets/#prefetch-related) is also the most directly analogous behavior in the ORM to how polymorphic iteration is performed. I think it is therefore appropriate to allow it to control the size of the get_real_instance queries.

The other complexity here is that different rdbms have different limits on the number of parameters that can be used in a SQL query. This comes into play because get_real_instances uses a WHERE IN query to fetch rows by pk. This PR will set the chunk_size to the minimum of the passed in chunk_size and the value of ``connection.features.max_query_params``.

*When there is no max param limit (postgresql) and the chunk limit exceeds the queryset size, django-polymorphic will now require 1+N queries where N is the number of polymorphic subclasses when iterating over Parent.objects.all(). On sqlite the max param size is 999, so the queries will require 1+N queries per 999 rows.*

**We still use `polymorphic.query.Polymorphic_QuerySet_objects_per_request` to set a default global chunk size. We bump this value from 100 to 2000 though to be in line with the default chunk_size [described in the Django docs](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#iterator).**