### PR TITLE
skip precommit hooks in precommit ci because just is not available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
+ci:
+  # Don't run these in pre-commit.ci at all
+  skip: [lint, format]
+
 repos:
   - repo: local
     hooks:
-    - id: lint
-      name: Lint
-      entry: just lint
-      language: system
-      pass_filenames: false
-    - id: format
-      name: Format
-      entry: just format
-      language: system
-      pass_filenames: false
+      - id: lint
+        name: Lint
+        entry: just lint
+        language: system
+        pass_filenames: false
+
+      - id: format
+        name: Format
+        entry: just format
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
I don't have enough admin access to turn off the unnecessary precommit running in CI. Our lint workflow does all those checks. Our precommit config needs just to be available and it isnt in precommit. This PR just skips the ling and format jobs if the context is precommit CI. This PR should be undone if someone can turn precommit CI off.