### PR TITLE
Fix ordering of stacked inline admin forms on add.

### DIFF
--- a/src/polymorphic/static/polymorphic/js/polymorphic_inlines.js
+++ b/src/polymorphic/static/polymorphic/js/polymorphic_inlines.js
@@ -118,13 +118,18 @@
                     // last child element of the form's container:
                     row.children(":first").append('<span><a class="' + options.deleteCssClass + '" href="#">' + options.deleteText + "</a></span>");
                 }
+                let totForms = parseInt(totalForms.val(), 10);
                 row.find("*").each(function() {
-                    updateElementIndex(this, options.prefix, totalForms.val());
+                    updateElementIndex(this, options.prefix, totForms);
+                });
+                row.find("h3 span.inline_label").each(function () {
+                    $(this).text($(this).text().replace(/##/g, `#${totForms+1}`));
                 });
                 // Insert the new form when it has been fully edited
-                row.insertBefore($(template));
+                const firstTemplate = $("#" + options.childTypes[0].type + "-empty");
+                row.insertBefore($(firstTemplate));
                 // Update number of total forms
-                $(totalForms).val(parseInt(totalForms.val(), 10) + 1);
+                $(totalForms).val(totForms+1);
                 nextIndex += 1;
                 // Hide add button in case we've hit the max, except we want to add infinitely
                 if ((maxForms.val() !== '') && (maxForms.val() - totalForms.val()) <= 0) {
@@ -161,6 +166,9 @@
                     for (i = 0, formCount = forms.length; i < formCount; i++) {
                         updateElementIndex($(forms).get(i), options.prefix, i);
                         $(forms.get(i)).find("*").each(updateElementCallback);
+                        $(forms.get(i)).find("h3 span.inline_label").each(function () {
+                            $(this).text($(this).text().replace(/#\d+/g, `#${i+1}`));
+                        });
                     }
                 });
                 // If a post-add callback was supplied, call it with the added form:

--- a/src/polymorphic/templates/admin/polymorphic/edit_inline/stacked.html
+++ b/src/polymorphic/templates/admin/polymorphic/edit_inline/stacked.html
@@ -15,7 +15,7 @@
        id="{% if inline_admin_form.original.pk %}{{ inline_admin_formset.formset.prefix }}-{{ forloop.counter0 }}{% else %}{{ inline_admin_form.model_admin.opts.model_name }}-empty{% endif %}">
 
     <h3><b>{{ inline_admin_form.model_admin.opts.verbose_name|capfirst }}:</b>&nbsp;<span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="inlinechangelink">{% trans "Change" %}</a>{% endif %}
-{% else %}#{{ forloop.counter }}{% endif %}</span>
+{% else %}##{% endif %}</span>
         {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% trans "View on site" %}</a>{% endif %}
       {% if inline_admin_form.formset.can_delete and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
     </h3>


### PR DESCRIPTION
Closes #426

Fix is taken from @ADR-007 in #426. The bug is very much still there today.