### PR TITLE
Improve Playwright setup for newcomers

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,6 +45,10 @@ install *OPTS:
     uv sync {{ OPTS }}
     @just run pre-commit install
 
+# install playwright dependencies
+install-playwright:
+    @just run playwright install
+
 # install documentation dependencies
 install-docs:
     uv sync --group docs --all-extras
@@ -185,10 +189,10 @@ test-lock +PACKAGES: _lock-python
     uv add {{ PACKAGES }}
 
 # run tests
-test *TESTS:
+test *TESTS: install-playwright
     @just run pytest --cov-append {{ TESTS }}
 
-test-db DB_CLIENT="dev" *TESTS:
+test-db DB_CLIENT="dev" *TESTS: install-playwright
     # No Optional Dependency Unit Tests
     # todo clean this up, rerunning a lot of tests
     uv sync --group {{ DB_CLIENT }}

--- a/src/polymorphic/tests/test_admin.py
+++ b/src/polymorphic/tests/test_admin.py
@@ -315,8 +315,16 @@ class _GenericAdminFormTest(StaticLiveServerTestCase):
         """Set up the test class with a live server and Playwright instance."""
         os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "1"
         super().setUpClass()
-        cls.playwright = sync_playwright().start()
-        cls.browser = cls.playwright.chromium.launch(headless=cls.HEADLESS)
+        try:
+            cls.playwright = sync_playwright().start()
+            cls.browser = cls.playwright.chromium.launch(headless=cls.HEADLESS)
+        except Exception as e:
+            if "asyncio loop" in str(e) or "executable" in str(e).lower():
+                raise RuntimeError(
+                    "Playwright failed to start. This often happens if browser drivers are missing. "
+                    "Please run 'just install-playwright' to install them."
+                ) from e
+            raise
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
- Add missing 'install-playwright' command to justfile
- Improve error message when browser drivers are missing

When new contributors run tests without Playwright browser drivers, they now see a helpful error message directing them to run 'just install-playwright' instead of a misleading asyncio error.

This makes the project more welcoming to newcomers by ensuring documented commands actually work and providing clear guidance when setup steps are missed.