### PR TITLE
Correctly implement PolymorphicModel.delete with keep_parents=True

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -268,8 +268,8 @@ Similarly, pre-V1.0 output formatting can be re-estated by using
 ``polymorphic_showfield_old_format = True``.
 
 
-Creating Subclass Objects from Existing Superclass Objects
-------------------------------------------------------------
+Create Children from Parents (Downcasting)
+------------------------------------------
 
 You can create an instance of a subclass from an existing instance of a superclass using the
 :meth:`~polymorphic.managers.PolymorphicManager.create_from_super` method
@@ -284,6 +284,15 @@ The restriction is that ``super_instance`` must be an instance of the direct sup
 ``ModelB``, and any required fields of ``ModelB`` must be provided as keyword arguments. If multiple
 levels of subclassing are involved, you must call this method multiple times to "promote" each
 level.
+
+Delete Children, Leaving Parents (Upcasting)
+--------------------------------------------
+
+The reverse operation of :meth:`~polymorphic.managers.PolymorphicManager.create_from_super` is to
+delete the subclass instance while keeping the superclass instance. This can be done using the
+``keep_parents=True`` argument to :meth:`~django.db.models.Model.delete`. :pypi:`django-polymorphic`
+ensures that the ``polymorphic_ctype`` fields of the superclass instances are updated accordingly
+when doing this.
 
 .. _restrictions:
 

--- a/docs/deletion.rst
+++ b/docs/deletion.rst
@@ -49,3 +49,19 @@ behavior during deletion collection. If you encounter an issue like this
             on_delete=PolymorphicGuard(models.CASCADE),
         )
 
+Deleting Children (upcasting)
+-----------------------------
+
+When deleting a polymorphic model instance, you can choose to keep the parent model instances by
+passing the ``keep_parents=True`` argument to the
+:meth:`~polymorphic.models.PolymorphicModel.delete` method. This will delete only the subclass
+instance, and leave the parent instances intact. :pypi:`django-polymorphic` will ensure that the
+``polymorphic_ctype`` fields of the parent instances are updated accordingly to reflect their new
+concrete model type.
+
+.. tip::
+
+    You can delete multiple levels of child rows by deleting the model from the desired parent
+    level. For example, if you have a model inheritance hierarchy of ``Base -> ChildA -> ChildB``,
+    and you delete a ``ChildB`` row from its parent model ``ChildA`` instance both the ``ChildA``
+    and ``ChildB`` rows will be deleted leaving a concrete row type of ``Base``.

--- a/src/polymorphic/tests/test_orm.py
+++ b/src/polymorphic/tests/test_orm.py
@@ -415,7 +415,7 @@ class PolymorphicTests(TransactionTestCase):
         qs_polymorphic = Model2A.objects.order_by("field1").all()
 
         assert list(qs_base) == [a, b_base, c_base]
-        assert list(qs_polymorphic) == [a, c]
+        assert list(qs_polymorphic) == [a, b_base, c]
 
     def test_queryset_missing_contenttype(self):
         stale_ct = ContentType.objects.create(app_label="tests", model="nonexisting")
@@ -1330,8 +1330,9 @@ class PolymorphicTests(TransactionTestCase):
         objects = list(qs)
         assert len(objects[0].many2many.all()) == 1
 
-        # derived object was not fetched
-        assert len(objects[1].many2many.all()) == 0
+        # derived object was upcast by deletion that keeps parents
+        assert len(objects[1].many2many.all()) == 1
+        assert objects[1].many2many.first() == Model2A.objects.get(field1="A2")
 
         # base object does exist
         assert len(objects[1].many2many.non_polymorphic()) == 1


### PR DESCRIPTION
so that the polymorphic_ctype column on the surviving parents is updated correctly.

Fixes #645