### PR TITLE
feat: Enhance pre-commit hooks to match CI validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,70 @@
 ci:
   # Don't run these in pre-commit.ci at all
-  skip: [lint, format]
+  skip: [lint, format, check-lint-strict, check-format-strict, check-package, check-readme, run-tests]
 
 repos:
   - repo: local
     hooks:
+      # Auto-fixing hooks (run first) - runs on changed files only
       - id: lint
-        name: Lint
-        entry: just lint
+        name: Lint (auto-fix)
+        entry: bash -c 'uv run ruff check --fix --select I "$@" && uv run ruff check --fix "$@"' --
         language: system
-        pass_filenames: false
+        pass_filenames: true
+        types: [python]
+        stages: [pre-commit]
+        verbose: true
 
       - id: format
-        name: Format
-        entry: just format
+        name: Format (auto-fix)
+        entry: uv run ruff format
+        language: system
+        pass_filenames: true
+        types: [python]
+        stages: [pre-commit]
+        verbose: true
+
+      # Validation hooks - runs on changed files only
+      - id: check-lint-strict
+        name: Check Lint (CI match)
+        entry: bash -c 'uv run ruff check --select I "$@" && uv run ruff check "$@"' --
+        language: system
+        pass_filenames: true
+        types: [python]
+        stages: [pre-commit]
+        verbose: true
+
+      - id: check-format-strict
+        name: Check Format (CI match)
+        entry: uv run ruff format --check
+        language: system
+        pass_filenames: true
+        types: [python]
+        stages: [pre-commit]
+        verbose: true
+
+      # Global checks (must run on whole project/env)
+      - id: check-package
+        name: Check Package (CI match)
+        entry: uv pip check
         language: system
         pass_filenames: false
+        stages: [pre-commit]
+        verbose: true
+
+      - id: check-readme
+        name: Check README (CI match)
+        entry: uv run -m readme_renderer ./README.md -o /tmp/README.html
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        verbose: true
+
+      # Optional: Run tests with coverage (manual stage only)
+      - id: run-tests
+        name: Run Tests with Coverage
+        entry: uv run pytest --cov-append
+        language: system
+        pass_filenames: false
+        stages: [manual]
+        verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,16 @@ max-line-length = 100
 sphinx = true
 
 [tool.ruff]
+force-exclude = true
 line-length = 99
 
 exclude = [
     "**/migrations/*.py",
     "**/migrations/**",
 ]
+
+[tool.ruff.format]
+exclude = ["**/migrations/**"]
 
 [tool.ruff.lint]
 extend-ignore = [


### PR DESCRIPTION
Improves the pre-commit configuration to provide local feedback that matches CI, reducing the need for multiple PR iterations due to linting issues.

## Changes

### Pre-commit Configuration (.pre-commit-config.yaml)

**New Hook Structure:**
- **Auto-fix hooks** (run first on changed files):
  - `lint`: Auto-fixes import sorting and linting issues via ruff
  - `format`: Auto-fixes code formatting via ruff

- **Validation hooks** (match CI exactly):
  - `check-lint-strict`: Mirrors `just check-lint` from CI
  - `check-format-strict`: Mirrors `just check-format` from CI
  - `check-package`: Mirrors `just check-package` (dependency check)
  - `check-readme`: Mirrors `just check-readme` (README rendering)

- **Manual hooks:**
  - `run-tests`: Available for manual test execution

**Key Improvements:**
- Direct `uv run ruff` commands instead of `just` delegation
- `pass_filenames: true` for faster incremental checks
- `types: [python]` filtering for efficiency
- `verbose: true` for clearer development feedback

### Ruff Configuration (pyproject.toml)

- Added `force-exclude = true` to ensure exclusions work with `pass_filenames: true`
- Added `[tool.ruff.format].exclude` for migration file exclusions

## Why This Matters

Before this change, developers would push code, wait for CI, discover lint failures, fix them, push again, and repeat. This created a slow feedback loop.

Now, the pre-commit hooks:
1. Auto-fix common issues before commit
2. Validate that code will pass CI checks locally
3. Properly exclude migration files
4. Provide verbose, helpful output

## Testing

All hooks pass on the full project:
```
Lint (auto-fix)...............Passed
Format (auto-fix).............Passed
Check Lint (CI match).........Passed
Check Format (CI match).......Passed
Check Package (CI match)......Passed
Check README (CI match).......Passed
```