### PR TITLE
Move helper functions off model interface and into utils

### DIFF
--- a/src/polymorphic/base.py
+++ b/src/polymorphic/base.py
@@ -85,9 +85,6 @@ class PolymorphicModelBase(ModelBase):
         if not new_class._meta.abstract and not new_class._meta.swapped:
             cls.validate_model_manager(new_class.objects, model_name, "objects")
 
-        # for __init__ function of this class (monkeypatching inheritance accessors)
-        new_class.polymorphic_super_sub_accessors_replaced = False
-
         # determine the name of the primary key field and store it into the class variable
         # polymorphic_primary_key_name (it is needed by query.py)
         if new_class._meta.pk:

--- a/src/polymorphic/models.py
+++ b/src/polymorphic/models.py
@@ -2,13 +2,9 @@
 Seamless Polymorphic Inheritance for Django Models
 """
 
-from dataclasses import dataclass
-from functools import lru_cache
-
 from django.contrib.contenttypes.models import ContentType
 from django.db import models, transaction
 from django.db.utils import DEFAULT_DB_ALIAS
-from django.utils.functional import classproperty
 
 from .base import PolymorphicModelBase
 from .managers import PolymorphicManager
@@ -16,16 +12,6 @@ from .query_translate import translate_polymorphic_Q_object
 
 ###################################################################################
 # PolymorphicModel
-
-
-@dataclass(frozen=True)
-class ParentLinkInfo:
-    """
-    Information about a parent table link in a polymorphic model.
-    """
-
-    model: models.Model
-    link: models.Field
 
 
 class PolymorphicTypeUndefined(LookupError):
@@ -106,8 +92,6 @@ class PolymorphicModel(models.Model, metaclass=PolymorphicModelBase):
                 self, for_concrete_model=False
             )
             self.polymorphic_ctype_id = ctype.pk
-
-    pre_save_polymorphic.alters_data = True
 
     def save(self, *args, **kwargs):
         """Calls :meth:`pre_save_polymorphic` and saves the model."""
@@ -213,72 +197,6 @@ class PolymorphicModel(models.Model, metaclass=PolymorphicModelBase):
                 f"#{self.pk} does not have a corresponding model!"
             )
         return self.__class__.objects.db_manager(self._state.db).get(pk=self.pk)
-
-    @classmethod
-    @lru_cache(maxsize=None)
-    def _route_to_ancestor(cls, ancestor_model):
-        """
-        Returns the first (highest mro precedence - depth first on parents) model
-        inheritance route to the given ancestor model - or an empty list if no such
-        route exists.
-
-        .. warning::
-
-            This is a private method subject to unannounced changes. This only works for
-            concrete ancestors!
-
-        Returns a :class:`list` of :class:`ParentLinkInfo`
-        """
-        route = []
-
-        def find_route(model, target_model, current_route):
-            if model is target_model:
-                return current_route
-
-            for parent_model, field_to_parent in model._meta.parents.items():
-                if field_to_parent is not None:
-                    new_route = current_route + [ParentLinkInfo(parent_model, field_to_parent)]
-                    found_route = find_route(parent_model, target_model, new_route)
-                    if found_route is not None:
-                        return found_route
-            return None
-
-        found_route = find_route(cls, ancestor_model, route)
-        if found_route is None:
-            return []
-        return found_route
-
-    @classproperty
-    def _concrete_descendants(cls):
-        """
-        A list of all concrete (non-abstract, non-proxy) descendant
-        model classes in tree order with leaf descendants last.
-
-        .. warning::
-
-            This is a private method subject to unannounced changes. Also do not call
-            it before all models are loaded or its results will be incomplete!
-        """
-        from django.apps import apps
-
-        apps.check_models_ready()
-
-        def add_concrete_descendants(model, result):
-            """Add concrete descendants in tree order (ancestors before descendants)."""
-            for sub_cls in model.__subclasses__():
-                if not issubclass(sub_cls, models.Model):
-                    continue
-
-                # Add concrete models in pre-order (parent before children)
-                if not sub_cls._meta.abstract and not sub_cls._meta.proxy:
-                    result.append(sub_cls)
-
-                # Always recurse to find descendants through abstract and proxy models
-                add_concrete_descendants(sub_cls, result)
-
-        result = []
-        add_concrete_descendants(cls, result)
-        return result
 
     def delete(self, using=None, keep_parents=False):
         """

--- a/src/polymorphic/query.py
+++ b/src/polymorphic/query.py
@@ -18,6 +18,7 @@ from .query_translate import (
     translate_polymorphic_filter_definitions_in_kwargs,
     translate_polymorphic_Q_object,
 )
+from .utils import concrete_descendants, route_to_ancestor
 
 Polymorphic_QuerySet_objects_per_request = 2000
 """
@@ -412,7 +413,7 @@ class PolymorphicQuerySet(QuerySet):
 
         class_priorities = {
             mdl: idx + 1
-            for idx, mdl in enumerate((*reversed(self.model._concrete_descendants), self.model))
+            for idx, mdl in enumerate((*reversed(concrete_descendants(self.model)), self.model))
         }
 
         for i, base_object in enumerate(base_result_objects):
@@ -505,7 +506,7 @@ class PolymorphicQuerySet(QuerySet):
                 if real_object is None:
                     # Our content type is pointing to a row that does not exist anymore
                     # We try to find the next best available parent row
-                    inheritance_path = real_concrete_class._route_to_ancestor(self.model)
+                    inheritance_path = route_to_ancestor(real_concrete_class, self.model)
                     if not inheritance_path or inheritance_path[0].model is self.model:
                         resultlist[result_idx] = base_object
                     else:


### PR DESCRIPTION
Also add some more caching for frequently used inheritance walking ops. This keeps the PolymorphicModel interface cleaner.