### PR TITLE
fix: add kwargs to save method to keep compatability with other tools…

### DIFF
--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -5,6 +5,9 @@ v4.11.7 (2026-07-31)
 --------------------
 
 * Support Django 6.1
+* Fixed `Regression: A recent update in the save method removed sending kwargs to the super.save
+  method breaking the save function
+  <https://github.com/django-commons/django-polymorphic/issues/905>`_
 
 
 v4.11.6 (2026-07-09)

--- a/src/polymorphic/models.py
+++ b/src/polymorphic/models.py
@@ -125,6 +125,7 @@ class PolymorphicModel(models.Model, metaclass=PolymorphicModelBase):
         force_update: bool = False,
         using: str | None = None,
         update_fields: Iterable[str] | None = None,
+        **kwargs,
     ) -> None:
         """Calls :meth:`pre_save_polymorphic` and saves the model."""
         # Determine the database to use via Django's routing infrastructure:
@@ -144,6 +145,7 @@ class PolymorphicModel(models.Model, metaclass=PolymorphicModelBase):
             force_update=force_update,
             using=using,
             update_fields=update_fields,
+            **kwargs,
         )
 
     save.alters_data = True  # type: ignore[attr-defined]

--- a/src/polymorphic/tests/migrations/0001_initial.py
+++ b/src/polymorphic/tests/migrations/0001_initial.py
@@ -1132,6 +1132,17 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
+            name='SaveKwargsModel',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=50)),
+                ('polymorphic_ctype', models.ForeignKey(editable=False, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='polymorphic_%(app_label)s.%(class)s_set+', to='contenttypes.contenttype')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
             name='RelatingModel',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),

--- a/src/polymorphic/tests/models.py
+++ b/src/polymorphic/tests/models.py
@@ -1138,3 +1138,23 @@ class PolymorphicTagB(PolymorphicTagBase):
     """Second child of PolymorphicTagBase with a different extra field."""
 
     color = models.CharField(max_length=20, default="")
+
+
+class SaveKwargsMixin(models.Model):
+    """
+    Mimics third-party abstract model mixins (e.g. django-lifecycle) whose
+    save() accepts extra keyword arguments (issue #905).
+    """
+
+    class Meta:
+        abstract = True
+
+    def save(self, *args, custom_kwarg=None, **kwargs):
+        self.captured_custom_kwarg = custom_kwarg
+        super().save(*args, **kwargs)
+
+
+class SaveKwargsModel(PolymorphicModel, SaveKwargsMixin):
+    """PolymorphicModel.save() must forward extra kwargs down the MRO (issue #905)."""
+
+    name = models.CharField(max_length=50)

--- a/src/polymorphic/tests/test_orm.py
+++ b/src/polymorphic/tests/test_orm.py
@@ -95,6 +95,7 @@ from polymorphic.tests.models import (
     RelationBase,
     RelationBC,
     RubberDuck,
+    SaveKwargsModel,
     SubclassSelectorAbstractBaseModel,
     SubclassSelectorAbstractConcreteModel,
     SubclassSelectorProxyBaseModel,
@@ -256,6 +257,21 @@ class PolymorphicTests(TransactionTestCase):
             transform=lambda o: o.__class__,
             ordered=False,
         )
+
+    def test_save_forwards_extra_kwargs(self):
+        """
+        Regression test for #905: save() must forward extra keyword arguments
+        down the MRO so mixins from other packages (e.g. django-lifecycle's
+        ``skip_hooks``) keep working when combined with PolymorphicModel.
+        """
+        obj = SaveKwargsModel(name="kwargs")
+        obj.save(custom_kwarg="passed-through")
+
+        self.assertEqual(obj.captured_custom_kwarg, "passed-through")
+        # the save itself must still complete normally
+        obj.refresh_from_db()
+        self.assertEqual(obj.name, "kwargs")
+        self.assertIsNotNone(obj.polymorphic_ctype_id)
 
     def test_defer_fields(self):
         self.create_model2abcd()


### PR DESCRIPTION
… overriding save such as django-lifecycle (fixes #905)